### PR TITLE
Scoped variants to colors (fixes #6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-theming",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A TailwindCSS plugin that helps with theming",
   "main": "dist/index.js",
   "author": {

--- a/src/Theming/Generator/utils.ts
+++ b/src/Theming/Generator/utils.ts
@@ -5,6 +5,7 @@ import { ColorVariant } from '../Variant/ColorVariant';
 import { OpacityVariant } from '../Variant/OpacityVariant';
 import { ThemeScheme } from '../Theme/ThemeScheme';
 import { CustomProperty } from '../CustomProperty/CustomProperty';
+import { Variant } from '../Variant/Variant';
 
 /**
  * Get the default theme out of an array of themes.
@@ -59,7 +60,27 @@ export function getColorVariableName(color: Color, config: Configuration): strin
  * @returns {string}
  */
 export function getColorVariantVariableName(variant: ColorVariant): string {
-  return `--color-variant-${variant.name}`;
+  return `--color-variant-${getFormattedVariantScope(variant)}${variant.name}`;
+}
+
+/**
+ * Get a string with the variant scope.
+ *
+ * @param variant
+ */
+export function getFormattedVariantScope(variant: Variant): string {
+  const scope = getVariantScope(variant);
+
+  return scope ? `${scope}-` : '';
+}
+
+/**
+ * Get the name of the variant's target or null.
+ *
+ * @param variant
+ */
+export function getVariantScope(variant: Variant): string | null {
+  return variant.colors.length === 1 ? variant.colors[0] : null;
 }
 
 /**
@@ -71,7 +92,7 @@ export function getColorVariantVariableName(variant: ColorVariant): string {
  * @returns {string}
  */
 export function getOpacityVariantVariableName(variant: OpacityVariant): string {
-  return `--opacity-variant-${variant.name}`;
+  return `--opacity-variant-${getFormattedVariantScope(variant)}${variant.name}`;
 }
 
 /**

--- a/src/Theming/Variant/ColorVariant.ts
+++ b/src/Theming/Variant/ColorVariant.ts
@@ -5,8 +5,8 @@ export class ColorVariant extends Variant {
   originalInput: string;
   color: TinyColor;
 
-  constructor(name: string, value: string) {
-    super(name);
+  constructor(name: string, value: string, colors?: string[]) {
+    super(name, colors);
 
     this.originalInput = value;
     this.color = new TinyColor(value);

--- a/src/Theming/Variant/OpacityVariant.ts
+++ b/src/Theming/Variant/OpacityVariant.ts
@@ -3,8 +3,8 @@ import { Variant } from "./Variant";
 export class OpacityVariant extends Variant {
   opacity: number;
 
-  constructor(name: string, value: number) {
-    super(name);
+  constructor(name: string, value: number, colors?: string[]) {
+    super(name, colors);
 
     this.opacity = value;
   }

--- a/src/Theming/Variant/Variant.ts
+++ b/src/Theming/Variant/Variant.ts
@@ -1,9 +1,13 @@
+import { Color } from "../Color/Color";
+
 export const DEFAULT_VARIANT_NAME = 'default';
 
 export abstract class Variant {
   name: string;
+  colors: string[];
 
-  constructor(name?: string) {
+  constructor(name?: string, colors?: string[]) {
     this.name = name || DEFAULT_VARIANT_NAME;
+    this.colors = colors || [];
   }
 }

--- a/test/configurations.test.ts
+++ b/test/configurations.test.ts
@@ -51,6 +51,44 @@ it('can be configured', () => {
   });
 });
 
+it('can have same variant names for different scopes', () => {
+  expect(() => {
+    new Theme()
+      .name('night')
+      .colors({
+        primary: 'white',
+        secondary: 'teal',
+      })
+      .colorVariant('light', '#FF569C', 'primary')
+      .colorVariant('light', '#FFFFFF', ['secondary']);
+  }).not.toThrow();
+});
+
+it('cannot duplicate unscoped variants', () => {
+  expect(() => {
+    new Theme()
+      .name('night')
+      .colors({
+        primary: 'white',
+        secondary: 'teal',
+      })
+      .colorVariant('light', '#FF569C')
+      .colorVariant('light', '#FFFFFF');
+  }).toThrowError('Variant light already exists.');
+});
+
+it('cannot duplicate scoped variants', () => {
+  expect(() => {
+    new Theme()
+      .name('night')
+      .colors({
+        primary: 'white',
+      })
+      .colorVariant('light', '#FF569C', 'primary')
+      .colorVariant('light', '#FF569C', ['primary']);
+  }).toThrowError("Variant light already exists for the color 'primary'.");
+});
+
 it('generates themes without variants', async () => {
   const theme = new Theme().name('night').colors({
     primary: 'white',
@@ -160,14 +198,14 @@ it('generates color configuration', () => {
   expect(getColorConfiguration([theme], plugin.theming)).toStrictEqual({
     primary: {
       default: 'rgb(var(--color-primary))',
-      hover: 'rgb(var(--color-variant-hover))',
+      hover: 'rgb(var(--color-variant-primary-hover))',
       blueish: 'rgb(var(--color-variant-blueish))',
       hidden: 'rgba(var(--color-primary), var(--opacity-variant-hidden))',
     },
     secondary: {
       default: 'rgb(var(--color-secondary))',
       blueish: 'rgb(var(--color-variant-blueish))',
-      disabled: 'rgba(var(--color-secondary), var(--opacity-variant-disabled))',
+      disabled: 'rgba(var(--color-secondary), var(--opacity-variant-secondary-disabled))',
       hidden: 'rgba(var(--color-secondary), var(--opacity-variant-hidden))',
     },
     brand: {
@@ -197,10 +235,10 @@ it('generates css variables', () => {
       '--color-primary': '255,255,255',
       '--color-secondary': '0,128,128',
       '--color-brand': '0,0,255',
-      '--color-variant-hover': '128,128,128',
+      '--color-variant-primary-hover': '128,128,128',
       '--color-variant-blueish': '0,0,255',
       '--opacity-variant-hidden': '0',
-      '--opacity-variant-disabled': '0.25',
+      '--opacity-variant-secondary-disabled': '0.25',
       '--int-var': '1',
       '--float-var': '1.2',
       '--array-var': 'value1,value2,1,1.2,spaced text,"spaced quote"', // avoid spaced text tho
@@ -222,10 +260,10 @@ it('warns at css configuration if a color is set in a theme but not the default 
       '--color-primary': '255,255,255',
       '--color-secondary': '0,128,128',
       '--color-brand': '0,0,255',
-      '--color-variant-hover': '128,128,128',
+      '--color-variant-primary-hover': '128,128,128',
       '--color-variant-blueish': '0,0,255',
       '--opacity-variant-hidden': '0',
-      '--opacity-variant-disabled': '0.25',
+      '--opacity-variant-secondary-disabled': '0.25',
     },
   });
 
@@ -242,10 +280,10 @@ it('generates css configuration', () => {
       '--color-primary': '255,255,255',
       '--color-secondary': '0,128,128',
       '--color-brand': '0,0,255',
-      '--color-variant-hover': '128,128,128',
+      '--color-variant-primary-hover': '128,128,128',
       '--color-variant-blueish': '0,0,255',
       '--opacity-variant-hidden': '0',
-      '--opacity-variant-disabled': '0.25',
+      '--opacity-variant-secondary-disabled': '0.25',
     },
   });
 
@@ -254,19 +292,19 @@ it('generates css configuration', () => {
       '--color-primary': '255,255,255',
       '--color-secondary': '0,128,128',
       '--color-brand': '0,0,255',
-      '--color-variant-hover': '128,128,128',
+      '--color-variant-primary-hover': '128,128,128',
       '--color-variant-blueish': '0,0,255',
       '--opacity-variant-hidden': '0',
-      '--opacity-variant-disabled': '0.25',
+      '--opacity-variant-secondary-disabled': '0.25',
     },
     '[someOtherTheme]': {
       '--color-primary': '255,255,255',
       '--color-secondary': '0,128,128',
       '--color-brand': '0,0,255',
-      '--color-variant-hover': '128,128,128',
+      '--color-variant-primary-hover': '128,128,128',
       '--color-variant-blueish': '0,0,255',
       '--opacity-variant-hidden': '0',
-      '--opacity-variant-disabled': '0.25',
+      '--opacity-variant-secondary-disabled': '0.25',
     },
   });
 });

--- a/test/tailwind.test.ts
+++ b/test/tailwind.test.ts
@@ -109,7 +109,7 @@ it('generates a tailwind configuration extension', async () => {
 
   plugin.themes([theme]);
 
-  const css = await generatePluginCss(plugin, undefined, true, true, true, [ 'fontFamily' ]);
+  const css = await generatePluginCss(plugin, undefined, true, true, true, ['fontFamily']);
 
   // @ts-ignore
   expect(css).toMatchCss(`
@@ -165,7 +165,7 @@ it('generates utilities with multiple colors and their variants', async () => {
         quaternary: '#ffffff1e',
       })
       .colorVariant('actually-black', 'black')
-      .colorVariant('darker', 'gray', ['primary'])
+      .colorVariant('darker', 'gray', 'primary')
       .colorVariant('hover', '#28282885', ['primary'])
       .opacityVariant('disabled', 0)
       .opacityVariant('less-opaque', 0.7, ['secondary', 'tertiary']),
@@ -183,8 +183,8 @@ it('generates utilities with multiple colors and their variants', async () => {
       --color-quaternary: 255, 255, 255;
       --color-variant-actually-black: 0, 0, 0;
       --opacity-variant-disabled: 0;
-      --color-variant-darker: 128, 128, 128;
-      --color-variant-hover: 40,40,40,0.5215686274509804;
+      --color-variant-primary-darker: 128, 128, 128;
+      --color-variant-primary-hover: 40,40,40,0.5215686274509804;
       --opacity-variant-less-opaque: 0.7
     }
     .text-transparent { color: rgba(var(--color-transparent), 0) } 
@@ -192,8 +192,8 @@ it('generates utilities with multiple colors and their variants', async () => {
     .text-transparent-disabled { color: rgba(var(--color-transparent), var(--opacity-variant-disabled)) } 
     .text-primary { color: rgb(var(--color-primary)) } 
     .text-primary-actually-black { color: rgb(var(--color-variant-actually-black)) } 
-    .text-primary-darker { color: rgb(var(--color-variant-darker)) } 
-    .text-primary-hover { color: rgba(var(--color-variant-hover)) } 
+    .text-primary-darker { color: rgb(var(--color-variant-primary-darker)) } 
+    .text-primary-hover { color: rgba(var(--color-variant-primary-hover)) } 
     .text-primary-disabled { color: rgba(var(--color-primary), var(--opacity-variant-disabled)) } 
     .text-secondary { color: rgb(var(--color-secondary)) } 
     .text-secondary-actually-black { color: rgb(var(--color-variant-actually-black)) } 
@@ -743,5 +743,42 @@ it('has a default themes using ThemeBuilder helper', async () => {
       :root {
         --color-main: 0,0,0
       }
+    }`);
+});
+
+it('generates variants with the same name for different scopes', async () => {
+  const plugin = new ThemeBuilder().default(
+    new Theme()
+      .default()
+      .colors({
+        'on-accent': '#FFFFFF',
+        accent: '#CB116E',
+
+        'on-primary': '#292929',
+        primary: '#FAFAFA',
+      })
+      .colorVariant('light', '#FF569C', 'accent')
+      .colorVariant('dark', '#940043', 'accent')
+      .colorVariant('light', '#FFFFFF', 'primary')
+      .colorVariant('dark', '#C7C7C7', 'primary')
+      .opacityVariant('slightly-visible', .2, 'accent')
+      .opacityVariant('slightly-visible', .1, 'primary')
+  );
+
+  const css = await generatePluginCss(plugin);
+
+  // @ts-ignore
+  expect(css).toMatchCss(`
+    :root {
+      --color-on-accent: 255,255,255;
+      --color-accent: 203,17,110;
+      --color-on-primary: 41,41,41;
+      --color-primary: 250,250,250;
+      --color-variant-accent-light: 255,86,156;
+      --color-variant-accent-dark: 148,0,67;
+      --opacity-variant-accent-slightly-visible: 0.2;
+      --color-variant-primary-light: 255,255,255;
+      --color-variant-primary-dark: 199,199,199;
+      --opacity-variant-primary-slightly-visible: 0.1;
     }`);
 });


### PR DESCRIPTION
This PR allows to scope variants to colors when variants are only tied to one color.

For instance, with a `primary` and a `secondary` color, the following will work:

```js
.colorVariant('light', '#FF569C', 'primary')
.colorVariant('light', '#FF569C', 'secondary')
```

Previously, it would fail. Now, the variant variable name for `primary`'s `light` will be `--color-variant-primary-light` instead of `--color-variant-light`. 

Note that the following will work just like before:

```js
.colorVariant('light', '#FF569C')
.colorVariant('light', '#FF569C', ['primary', 'secondary'])
```

This would throw an exception since neither of them are tied to only one color.